### PR TITLE
feat: add support for type checkers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ all = [
 [project.urls]
 "Homepage" = "https://github.com/jordantshaw/pydantic-config"
 
+[tool.setuptools.package-data]
+"pydantic_config" = ["py.typed"]
+
 [tool.pytest.ini_options]
 pythonpath = [
   "src"

--- a/src/pydantic_config/__init__.py
+++ b/src/pydantic_config/__init__.py
@@ -1,1 +1,3 @@
+__all__ = ["SettingsModel", "SettingsConfig", "SettingsError", "ConfigFileType"]
+
 from .main import SettingsModel, SettingsConfig, SettingsError, ConfigFileType


### PR DESCRIPTION
Hi!  
Thanks for this nice little convenience library :)

The source code is properly type-annotated, so I just had to create `py.typed` file and explicitly export `SettingsModel` and `SettingsConfig` from `__init__.py`.  
Hope this MR would be accepted so that enyone could use this library with type checkers such as `mypy` or `pyright`.

(Of course, no tests failed after this change)