### PR TITLE
feat: export SettingsError and ConfigFileType from package root

### DIFF
--- a/src/pydantic_config/__init__.py
+++ b/src/pydantic_config/__init__.py
@@ -1,1 +1,1 @@
-from .main import SettingsModel, SettingsConfig
+from .main import SettingsModel, SettingsConfig, SettingsError, ConfigFileType

--- a/src/pydantic_config/main.py
+++ b/src/pydantic_config/main.py
@@ -50,7 +50,7 @@ class SettingsModel(BaseSettings):
 
 
 class ConfigFileSettingsSource(PydanticBaseEnvSettingsSource):
-    """ Settings source class that loads values from one more configuration files. """
+    """ Settings source class that loads values from one more configuration files. Internal use only. """
     def __init__(
             self,
             settings_cls: Type[BaseSettings],


### PR DESCRIPTION
## Summary

- Exports `SettingsError` and `ConfigFileType` from `__init__.py` so users can import them directly from the package root
- Marks `ConfigFileSettingsSource` as internal-use only in its docstring