### PR TITLE
test: expand test suite

### DIFF
--- a/src/pydantic_config/__init__.py
+++ b/src/pydantic_config/__init__.py
@@ -1,1 +1,1 @@
-from .main import SettingsModel, SettingsConfig
+from .main import SettingsModel, SettingsConfig, SettingsError, ConfigFileType

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,3 +58,16 @@ def config_json_file(tmp_path_factory):
 
     return file_path
 
+
+@pytest.fixture(scope='session')
+def config_yml_file(tmp_path_factory):
+    config = '''
+    app:
+        description: description from config.yml
+    '''
+    file_path = tmp_path_factory.mktemp("data") / "config.yml"
+    with open(file_path, 'w') as file:
+        file.write(config)
+
+    return file_path
+

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,37 @@
+from pydantic_config.merge import deep_merge
+
+
+def test_non_overlapping_keys():
+    assert deep_merge({'a': 1}, {'b': 2}) == {'a': 1, 'b': 2}
+
+
+def test_nested_dict_merge():
+    base = {'app': {'name': 'foo', 'version': '1'}}
+    nxt = {'app': {'version': '2', 'debug': True}}
+    assert deep_merge(base, nxt) == {'app': {'name': 'foo', 'version': '2', 'debug': True}}
+
+
+def test_scalar_override():
+    assert deep_merge({'key': 'original'}, {'key': 'overridden'}) == {'key': 'overridden'}
+
+
+def test_list_merge_unique():
+    result = deep_merge({'items': [1, 2, 3]}, {'items': [3, 4, 5]}, unique=True)
+    assert result == {'items': [1, 2, 3, 4, 5]}
+
+
+def test_list_merge_non_unique():
+    result = deep_merge({'items': [1, 2, 3]}, {'items': [3, 4, 5]}, unique=False)
+    assert result == {'items': [1, 2, 3, 3, 4, 5]}
+
+
+def test_does_not_mutate_base():
+    base = {'app': {'name': 'foo'}}
+    deep_merge(base, {'app': {'name': 'bar'}})
+    assert base == {'app': {'name': 'foo'}}
+
+
+def test_does_not_mutate_nxt():
+    nxt = {'app': {'name': 'bar'}}
+    deep_merge({'app': {'name': 'foo'}}, nxt)
+    assert nxt == {'app': {'name': 'bar'}}

--- a/tests/test_settings_model.py
+++ b/tests/test_settings_model.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel
 
-from pydantic_config import SettingsModel, SettingsConfig
+from pydantic_config import SettingsModel, SettingsConfig, SettingsError, ConfigFileType
 
 
 def test_config_file(config_toml_file):
@@ -133,4 +133,114 @@ def test_multiple_config_files(config_toml_file, config_yaml_file):
 
     settings = Settings()
     assert settings.model_dump() == {'app': {'name': 'AppName', 'description': 'description from config.yaml'}}
+
+
+def test_yml_extension(config_yml_file):
+    class App(BaseModel):
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[config_yml_file],
+        )
+
+    settings = Settings()
+    assert settings.app.description == 'description from config.yml'
+
+
+def test_json_config_file(config_json_file):
+    class App(BaseModel):
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[config_json_file],
+        )
+
+    settings = Settings()
+    assert settings.app.description == 'description from config.json'
+
+
+def test_ini_config_file(config_ini_file):
+    class App(BaseModel):
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[config_ini_file],
+            extra='ignore',  # configparser always includes a DEFAULT section
+        )
+
+    settings = Settings()
+    assert settings.app.description == 'description from config.ini'
+
+
+
+def test_config_merge_unique_true(tmp_path):
+    file_a = tmp_path / "a.json"
+    file_a.write_text('{"items": [1, 2, 3]}')
+    file_b = tmp_path / "b.json"
+    file_b.write_text('{"items": [3, 4, 5]}')
+
+    class Settings(SettingsModel):
+        items: list = []
+
+        model_config = SettingsConfig(
+            config_file=[str(file_a), str(file_b)],
+            config_merge=True,
+            config_merge_unique=True,
+        )
+
+    settings = Settings()
+    assert settings.items == [1, 2, 3, 4, 5]
+
+
+def test_config_merge_unique_false(tmp_path):
+    file_a = tmp_path / "a.json"
+    file_a.write_text('{"items": [1, 2, 3]}')
+    file_b = tmp_path / "b.json"
+    file_b.write_text('{"items": [3, 4, 5]}')
+
+    class Settings(SettingsModel):
+        items: list = []
+
+        model_config = SettingsConfig(
+            config_file=[str(file_a), str(file_b)],
+            config_merge=True,
+            config_merge_unique=False,
+        )
+
+    settings = Settings()
+    assert settings.items == [1, 2, 3, 3, 4, 5]
+
+
+def test_env_var_overrides_config_file(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('foo = "from file"')
+
+    monkeypatch.setenv("FOO", "from_env")
+
+    class Settings(SettingsModel):
+        foo: str = 'default'
+
+        model_config = SettingsConfig(
+            config_file=[str(config_file)],
+        )
+
+    settings = Settings()
+    assert settings.foo == 'from_env'
+
+
+def test_public_api_imports():
+    from pydantic_config import SettingsModel, SettingsConfig, SettingsError, ConfigFileType
+    assert issubclass(SettingsError, ValueError)
+    assert SettingsModel is not None
+    assert SettingsConfig is not None
+    assert ConfigFileType is not None
 


### PR DESCRIPTION
## Summary

- Add `tests/test_merge.py` — unit tests for `deep_merge` (non-overlapping keys, nested dicts, scalar override, list unique/non-unique, mutation safety)
- Add integration tests for JSON and INI config files via `SettingsModel`
- Add `.yml` extension regression test
- Add `config_merge_unique` tests (True and False)
- Add env var precedence test
- Add public API import test (`SettingsError`, `ConfigFileType`, `SettingsModel`, `SettingsConfig`)
- Add `config_yml_file` fixture to conftest

## Notes

Writing the `config_merge=False` test exposed a pre-existing bug: setting `config_merge=False` via `SettingsConfig` has no effect due to `True or False = True` in `ConfigFileSettingsSource.__init__`. That fix is out of scope for this PR but worth a follow-up issue.