### PR TITLE
fix: config_merge and config_merge_unique False values now respected

### DIFF
--- a/src/pydantic_config/main.py
+++ b/src/pydantic_config/main.py
@@ -58,8 +58,8 @@ class ConfigFileSettingsSource(PydanticBaseEnvSettingsSource):
             config_file: Union[ConfigFileType, None] = None,
             config_file_required: bool = False,
             config_file_encoding: Union[str, None] = None,
-            config_merge: bool = True,
-            config_merge_unique: bool = False,
+            config_merge: Union[bool, None] = None,
+            config_merge_unique: Union[bool, None] = None,
 
     ) -> None:
         super().__init__(settings_cls, case_sensitive)
@@ -67,8 +67,8 @@ class ConfigFileSettingsSource(PydanticBaseEnvSettingsSource):
         self.config_file = config_file or self.config.get('config_file', None)
         self.config_file_required = config_file_required or self.config.get('config_file_required', None)
         self.config_file_encoding = config_file_encoding or self.config.get('config_file_encoding', None)
-        self.config_merge = config_merge or self.config.get('config_merge', True)
-        self.config_merge_unique = config_merge_unique or self.config.get('config_merge_unique', True)
+        self.config_merge = config_merge if config_merge is not None else self.config.get('config_merge', True)
+        self.config_merge_unique = config_merge_unique if config_merge_unique is not None else self.config.get('config_merge_unique', False)
         self.config_values = self._load_config_values()
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> Tuple[Any, str, bool]:

--- a/tests/test_settings_model.py
+++ b/tests/test_settings_model.py
@@ -119,6 +119,30 @@ def test_empty_config_file():
         Settings()
 
 
+def test_config_merge_disabled(tmp_path):
+    file_a = tmp_path / "a.toml"
+    file_a.write_text('[app]\nname = "from file a"\ndescription = "from file a"')
+    file_b = tmp_path / "b.toml"
+    file_b.write_text('[app]\ndescription = "from file b"')
+
+    class App(BaseModel):
+        name: str = 'default'
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[str(file_a), str(file_b)],
+            config_merge=False,
+        )
+
+    settings = Settings()
+    # file b replaces file a entirely — name is not in file b so falls back to default
+    assert settings.app.name == 'default'
+    assert settings.app.description == 'from file b'
+
+
 def test_multiple_config_files(config_toml_file, config_yaml_file):
     class App(BaseModel):
         name: str = 'AppName'


### PR DESCRIPTION
## Summary

- Fixes a bug where setting `config_merge=False` or `config_merge_unique=False` via `SettingsConfig` was silently ignored
- Root cause: `True or False = True` — the constructor used `or` to resolve values, so an explicit `False` would always be overridden by the default
- Fix: changed both args to default to `None` and use `is not None` to distinguish "not set" from `False`
- Adds a regression test for `config_merge=False`