### PR TITLE
release: v0.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,6 @@ name: Test
 on:
   push:
     branches: [ "*" ]
-  pull_request:
-    branches: [ "*" ]
 
 jobs:
   build:
@@ -15,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ name: Test
 on:
   push:
     branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
 
 jobs:
   build:
@@ -13,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3
@@ -35,3 +37,14 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+
+  test-summary:
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check all tests passed
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install pydantic-config
 Or with conda (via the conda-forge channel):
 ```bash
 conda install pydantic-config -c conda-forge
-
+```
 
 ### Optional Dependencies
 To enable additional file formats, you can install optional dependencies:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ JSON, INI, TOML, and YAML — in addition to environment variables.
 - [Supported File Formats](#supported-file-formats)
 - [Using `.env` Files](#using-env-files)
 - [Requiring Config Files to Exist](#requiring-config-files-to-exist)
-- [Merging Configuration Values](#merging-configuration-values)
+- [Merging](#merging)
 - [Handling Duplicates in Merged Lists](#handling-duplicates-in-merged-lists)
 - [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,76 @@
 # Pydantic Config
-Support for Pydantic settings configuration file loading
+Pydantic Config extends Pydantic’s BaseSettings to support loading configuration from files like 
+JSON, INI, TOML, and YAML — in addition to environment variables.
+
+[![PyPI](https://img.shields.io/pypi/v/pydantic-config.svg)](https://pypi.org/project/pydantic-config/)
+[![Conda](https://img.shields.io/conda/vn/conda-forge/pydantic-config.svg)](https://anaconda.org/conda-forge/pydantic-config)
+[![License](https://img.shields.io/github/license/jordantshaw/pydantic-config)](https://github.com/jordantshaw/pydantic-config/blob/main/LICENSE)
+
+---
+
+## Table of Contents
+
+- [Why Pydantic Config?](#why-pydantic-config)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Loading Multiple Config Files](#loading-multiple-config-files)
+- [Supported File Formats](#supported-file-formats)
+- [Using `.env` Files](#using-env-files)
+- [Requiring Config Files to Exist](#requiring-config-files-to-exist)
+- [Merging Configuration Values](#merging-configuration-values)
+- [Handling Duplicates in Merged Lists](#handling-duplicates-in-merged-lists)
+- [License](#license)
+
+---
+
+## Why Pydantic Config?
+✅ Load settings from `.json`, `.ini`, `.toml`, `.yaml`, and `.env` files.  
+✅ Support for multiple files with override/merge strategies.  
+✅ Compatible with Pydantic v2 `BaseSettings`.  
+✅ Lightweight and simple integration.
+
+---
 
 ## Installation
-Pydantic Config can be installed via pip:
+Install with pip:
+```bash
+pip install pydantic-config
+```
 
-`pip install pydantic-config`
-
-Pydantic Config is also available on conda under the conda-forge channel:
-
-`conda install pydantic-config -c conda-forge`
-
+Or with conda (via the conda-forge channel):
+```bash
+conda install pydantic-config -c conda-forge
 
 
 ### Optional Dependencies
+To enable additional file formats, you can install optional dependencies:
 
-Pydantic-Config has the following optional dependencies:
-  - yaml - `pip install pydantic-config[yaml]`
-  - toml - `pip install pydantic-config[toml]` _Only for python<3.11_
+| Format | Install Command |
+|:-------|:----------------|
+| YAML   | `pip install pydantic-config[yaml]` |
+| TOML (for Python < 3.11) | `pip install pydantic-config[toml]` |
 
-You can install all the optional dependencies with `pip install pydantic-config[all]`
+To install **all** optional dependencies:
 
-## Usage
+```bash
+pip install pydantic-config[all]
+```
 
+---
+
+## Quick Start
+
+Load settings from a config file:
+
+**config.toml**
 ```toml
-# config.toml
 app_name = "Python Application"
 description = "Test application description"
 ```
 
+**settings.py**
 ```python
 from pydantic_config import SettingsModel, SettingsConfig
-
 
 class Settings(SettingsModel):
     app_id: str = 1
@@ -42,35 +82,35 @@ class Settings(SettingsModel):
         config_file='config.toml',
     )
 
-
 settings = Settings()
 print(settings)
 # app_id='1' app_name='Python Application' description='Test application description' log_level='INFO'
 
 ```
 
-## Using multiple config files
+---
+
+## Loading Multiple Config Files
 Multiple config files can be loaded by passing a `list` of file names. Files will be loaded in the order they are listed.
 Meaning later files in the `list` will take priority over earlier files.
 
+**config.toml**
 ```toml
-# config.toml
 app_name = "Python Application"
 description = "Test application description"
 ```
 
-
+**config.json**
 ```json
-// config.json
 {
   "description": "Description from JSON file",
   "log_level": "WARNING"
 }
 ```
 
+**settings.py**
 ```python
 from pydantic_config import SettingsModel, SettingsConfig
-
 
 class Settings(SettingsModel):
     app_id: str = 1
@@ -87,19 +127,24 @@ print(settings)
 # app_id='1' app_name='Python Application' description='Description from JSON file' log_level='WARNING'
 ```
 
-## Supported file formats
+---
+
+## Supported File Formats
 Currently, the following file formats are supported:
   - `.yaml` _Requires `pyyaml` package_
   - `.toml` _Requires `tomli` package for python<3.11_
   - `.json`
   - `.ini`
 
-## Using dotenv files
-`pydantic-config` supports using dotenv files because `pydantic-settings` natively supports dotenv files. 
-To use a dotenv file in conjunction with the config files simply set `env_file` parameter in `SettingsConfig`.
-The values in the dotenv file will take precedence over the values in the config files.
+---
+
+## Using `.env` files
+Since Pydantic natively supports dotenv files, you can combine a `.env` file with config files easily.  
+Values from the `.env` file **take precedence** over config files.
 
 ```python
+from pydantic_config import SettingsModel, SettingsConfig
+
 class Settings(SettingsModel):
   app_name: str = None
   description: str = None
@@ -110,57 +155,89 @@ class Settings(SettingsModel):
     )
 ```
 
+---
 
-## Requiring config files to load
-Config files will attempt to be loaded from the specified file path. By default, if no file is found the file 
-will simply not be loaded (no error occurs). This may be useful if you want to specify config files that 
-may or may not exist. For example, you may have different config files for per 
+## Requiring Config Files to Exist
+By default, missing config files are ignored (no error is raised). This may be useful if you want to specify 
+config files that may not always exist. For example, you might have different config files for per 
 environment: `config-prod.toml` and `config-dev.toml`.
 
-To disable this behavior set `config_file_required=True`. This will cause an error to be raised
-if the specified config file(s) do not exist. Setting this to `True` will also prohibit the `config_file`
-parameter from being set to `None` or empty `[]`.
+To enforce that config files must exist, set `config_file_required=True`. This will cause an error to be raised
+if the specified config file(s) does not exist. 
 
+```python
+model_config = SettingsConfig(
+    config_file='config.toml',
+    config_file_required=True,
+)
+```
+
+⚠️ When `config_file_required=True`, `config_file` cannot be `None` or an empty list `[]`.
+
+---
 
 ## Merging
-If your configurations have existing `list` or `dict` variables the contents will be merged by default. To disable
-this behavior and override the contents instead you can set the `config_merge` option to `False` in the settings 
-`Config` class.
+By default, when merging multiple config files:
+- `dict` values are **merged** (keys combined).
+- `list` values are **merged** (items combined).
 
+To disable merging and prefer overwriting entirely, set `config_merge=False`.
+
+**Example:**
+
+**config.toml**
 ```toml
-# config.toml
 [foo]
 item1 = "value1"
 ```
+
+**config2.toml**
 ```toml
-# config2.toml
 [foo]
 item2 = "value2"
 ```
 
+**settings.py**
 ```python
 from pydantic_config import SettingsModel, SettingsConfig
 
-
 class Settings(SettingsModel):
     foo: dict = {}
-    
+
     model_config = SettingsConfig(
         config_file=['config.toml', 'config2.toml'],
-        config_merge= True,
+        config_merge=True,
     )
-
 
 settings = Settings()
 print(settings)
 # foo={'item1': 'value1', 'item2': 'value2'}
-
-# If config_merge=False then config2.toml would override the values from config.toml
-# foo={'item2': 'value2'}
 ```
 
-## Duplicate items in merged lists
-By default, __all__ `list` items will be merged into a single list regardless of duplicated items. To only keep
-unique list items, set `config_merge_unique=True`. This will only keep unique items in within a list.
+If `config_merge=False`, the second file would **overwrite** the first:
+
+```text
+foo={'item2': 'value2'}
+```
+
+---
+
+## Handling Duplicates in Merged Lists
+By default, merged lists **include all items**, even duplicates.
+
+To ensure list items are **unique** during merge, set `config_merge_unique=True`.
+
+```python
+model_config = SettingsConfig(
+    config_file=['config1.toml', 'config2.toml'],
+    config_merge=True,
+    config_merge_unique=True,
+)
+```
+
+
+## License
+This project is licensed under the [MIT License](https://github.com/jordantshaw/pydantic-config/blob/main/LICENSE).
+
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ all = [
 [project.urls]
 "Homepage" = "https://github.com/jordantshaw/pydantic-config"
 
+[tool.setuptools.package-data]
+"pydantic_config" = ["py.typed"]
+
 [tool.pytest.ini_options]
 pythonpath = [
   "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pydantic-config"
 description = "Support for Pydantic settings configuration file loading"
-version = "0.3.0"
+version = "0.4.0"
 authors = [{name="Jordan Shaw"}]
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/pydantic_config/__init__.py
+++ b/src/pydantic_config/__init__.py
@@ -1,1 +1,3 @@
+__all__ = ["SettingsModel", "SettingsConfig", "SettingsError", "ConfigFileType"]
+
 from .main import SettingsModel, SettingsConfig, SettingsError, ConfigFileType

--- a/src/pydantic_config/__init__.py
+++ b/src/pydantic_config/__init__.py
@@ -1,1 +1,1 @@
-from .main import SettingsModel, SettingsConfig
+from .main import SettingsModel, SettingsConfig, SettingsError, ConfigFileType

--- a/src/pydantic_config/main.py
+++ b/src/pydantic_config/main.py
@@ -58,8 +58,8 @@ class ConfigFileSettingsSource(PydanticBaseEnvSettingsSource):
             config_file: Union[ConfigFileType, None] = None,
             config_file_required: bool = False,
             config_file_encoding: Union[str, None] = None,
-            config_merge: bool = True,
-            config_merge_unique: bool = False,
+            config_merge: Union[bool, None] = None,
+            config_merge_unique: Union[bool, None] = None,
 
     ) -> None:
         super().__init__(settings_cls, case_sensitive)
@@ -67,8 +67,8 @@ class ConfigFileSettingsSource(PydanticBaseEnvSettingsSource):
         self.config_file = config_file or self.config.get('config_file', None)
         self.config_file_required = config_file_required or self.config.get('config_file_required', None)
         self.config_file_encoding = config_file_encoding or self.config.get('config_file_encoding', None)
-        self.config_merge = config_merge or self.config.get('config_merge', True)
-        self.config_merge_unique = config_merge_unique or self.config.get('config_merge_unique', True)
+        self.config_merge = config_merge if config_merge is not None else self.config.get('config_merge', True)
+        self.config_merge_unique = config_merge_unique if config_merge_unique is not None else self.config.get('config_merge_unique', False)
         self.config_values = self._load_config_values()
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> Tuple[Any, str, bool]:

--- a/src/pydantic_config/main.py
+++ b/src/pydantic_config/main.py
@@ -50,7 +50,7 @@ class SettingsModel(BaseSettings):
 
 
 class ConfigFileSettingsSource(PydanticBaseEnvSettingsSource):
-    """ Settings source class that loads values from one more configuration files. """
+    """ Settings source class that loads values from one more configuration files. Internal use only. """
     def __init__(
             self,
             settings_cls: Type[BaseSettings],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,3 +58,16 @@ def config_json_file(tmp_path_factory):
 
     return file_path
 
+
+@pytest.fixture(scope='session')
+def config_yml_file(tmp_path_factory):
+    config = '''
+    app:
+        description: description from config.yml
+    '''
+    file_path = tmp_path_factory.mktemp("data") / "config.yml"
+    with open(file_path, 'w') as file:
+        file.write(config)
+
+    return file_path
+

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,37 @@
+from pydantic_config.merge import deep_merge
+
+
+def test_non_overlapping_keys():
+    assert deep_merge({'a': 1}, {'b': 2}) == {'a': 1, 'b': 2}
+
+
+def test_nested_dict_merge():
+    base = {'app': {'name': 'foo', 'version': '1'}}
+    nxt = {'app': {'version': '2', 'debug': True}}
+    assert deep_merge(base, nxt) == {'app': {'name': 'foo', 'version': '2', 'debug': True}}
+
+
+def test_scalar_override():
+    assert deep_merge({'key': 'original'}, {'key': 'overridden'}) == {'key': 'overridden'}
+
+
+def test_list_merge_unique():
+    result = deep_merge({'items': [1, 2, 3]}, {'items': [3, 4, 5]}, unique=True)
+    assert result == {'items': [1, 2, 3, 4, 5]}
+
+
+def test_list_merge_non_unique():
+    result = deep_merge({'items': [1, 2, 3]}, {'items': [3, 4, 5]}, unique=False)
+    assert result == {'items': [1, 2, 3, 3, 4, 5]}
+
+
+def test_does_not_mutate_base():
+    base = {'app': {'name': 'foo'}}
+    deep_merge(base, {'app': {'name': 'bar'}})
+    assert base == {'app': {'name': 'foo'}}
+
+
+def test_does_not_mutate_nxt():
+    nxt = {'app': {'name': 'bar'}}
+    deep_merge({'app': {'name': 'foo'}}, nxt)
+    assert nxt == {'app': {'name': 'bar'}}

--- a/tests/test_settings_model.py
+++ b/tests/test_settings_model.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import BaseModel
 
-from pydantic_config import SettingsModel, SettingsConfig
+from pydantic_config import SettingsModel, SettingsConfig, SettingsError, ConfigFileType
 
 
 def test_config_file(config_toml_file):
@@ -133,4 +133,114 @@ def test_multiple_config_files(config_toml_file, config_yaml_file):
 
     settings = Settings()
     assert settings.model_dump() == {'app': {'name': 'AppName', 'description': 'description from config.yaml'}}
+
+
+def test_yml_extension(config_yml_file):
+    class App(BaseModel):
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[config_yml_file],
+        )
+
+    settings = Settings()
+    assert settings.app.description == 'description from config.yml'
+
+
+def test_json_config_file(config_json_file):
+    class App(BaseModel):
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[config_json_file],
+        )
+
+    settings = Settings()
+    assert settings.app.description == 'description from config.json'
+
+
+def test_ini_config_file(config_ini_file):
+    class App(BaseModel):
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[config_ini_file],
+            extra='ignore',  # configparser always includes a DEFAULT section
+        )
+
+    settings = Settings()
+    assert settings.app.description == 'description from config.ini'
+
+
+
+def test_config_merge_unique_true(tmp_path):
+    file_a = tmp_path / "a.json"
+    file_a.write_text('{"items": [1, 2, 3]}')
+    file_b = tmp_path / "b.json"
+    file_b.write_text('{"items": [3, 4, 5]}')
+
+    class Settings(SettingsModel):
+        items: list = []
+
+        model_config = SettingsConfig(
+            config_file=[str(file_a), str(file_b)],
+            config_merge=True,
+            config_merge_unique=True,
+        )
+
+    settings = Settings()
+    assert settings.items == [1, 2, 3, 4, 5]
+
+
+def test_config_merge_unique_false(tmp_path):
+    file_a = tmp_path / "a.json"
+    file_a.write_text('{"items": [1, 2, 3]}')
+    file_b = tmp_path / "b.json"
+    file_b.write_text('{"items": [3, 4, 5]}')
+
+    class Settings(SettingsModel):
+        items: list = []
+
+        model_config = SettingsConfig(
+            config_file=[str(file_a), str(file_b)],
+            config_merge=True,
+            config_merge_unique=False,
+        )
+
+    settings = Settings()
+    assert settings.items == [1, 2, 3, 3, 4, 5]
+
+
+def test_env_var_overrides_config_file(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('foo = "from file"')
+
+    monkeypatch.setenv("FOO", "from_env")
+
+    class Settings(SettingsModel):
+        foo: str = 'default'
+
+        model_config = SettingsConfig(
+            config_file=[str(config_file)],
+        )
+
+    settings = Settings()
+    assert settings.foo == 'from_env'
+
+
+def test_public_api_imports():
+    from pydantic_config import SettingsModel, SettingsConfig, SettingsError, ConfigFileType
+    assert issubclass(SettingsError, ValueError)
+    assert SettingsModel is not None
+    assert SettingsConfig is not None
+    assert ConfigFileType is not None
 

--- a/tests/test_settings_model.py
+++ b/tests/test_settings_model.py
@@ -119,6 +119,30 @@ def test_empty_config_file():
         Settings()
 
 
+def test_config_merge_disabled(tmp_path):
+    file_a = tmp_path / "a.toml"
+    file_a.write_text('[app]\nname = "from file a"\ndescription = "from file a"')
+    file_b = tmp_path / "b.toml"
+    file_b.write_text('[app]\ndescription = "from file b"')
+
+    class App(BaseModel):
+        name: str = 'default'
+        description: str = None
+
+    class Settings(SettingsModel):
+        app: App
+
+        model_config = SettingsConfig(
+            config_file=[str(file_a), str(file_b)],
+            config_merge=False,
+        )
+
+    settings = Settings()
+    # file b replaces file a entirely — name is not in file b so falls back to default
+    assert settings.app.name == 'default'
+    assert settings.app.description == 'from file b'
+
+
 def test_multiple_config_files(config_toml_file, config_yaml_file):
     class App(BaseModel):
         name: str = 'AppName'


### PR DESCRIPTION
## Summary

- feat: add support for type checkers
- feat: export `SettingsError` and `ConfigFileType` from package root
- fix: `config_merge` and `config_merge_unique` False values now respected
- fix: support `.yml` file suffix
- ci: run tests on PRs, add Python 3.12 and 3.13 to matrix
- test: expand test suite with merge, integration, and API tests
- docs: readme improvements
- chore: bump version to 0.4.0

## Test Plan

- [x] All 27 tests passing locally (Python 3.13)
- [x] CI matrix covers Python 3.12 and 3.13