### PR TITLE
chore: sync main back to develop after v0.4.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pydantic-config"
 description = "Support for Pydantic settings configuration file loading"
-version = "0.3.0"
+version = "0.4.0"
 authors = [{name="Jordan Shaw"}]
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## Summary

- Syncs the version bump (`0.3.0` → `0.4.0`) from the v0.4.0 release back into `develop`

## Test Plan

- [x] No conflicts — only change is the version in `pyproject.toml`